### PR TITLE
Fix to the parsing of additional_properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Add a new resource type to your Concourse CI pipeline:
   instance. This field is *required* when using SonarCloud to perform the analysis
   of your code.
 
-* `login`: *Required.* The login or authentication token of a SonarQube user with Execute Analysis
-  permission.
+* `login`: The login or authentication token of a SonarQube user with Execute Analysis
+  permission. Can be left out if SonarQube instance does not require any authentication.
 
 * `password`: The password that goes with the sonar.login username. This should be left blank if an
   authentication token is being used.

--- a/assets/out
+++ b/assets/out
@@ -54,10 +54,7 @@ if [ ! -z "${sonar_organization}" ]; then
 fi
 
 sonar_login=$(jq -r '.source.login // ""' < "${payload}")
-if [ -z "${sonar_login}" ]; then
-  echo "error: source.login has not been specified."
-  exit 1
-else
+if [ ! -z "${sonar_login}" ]; then
   scanner_opts+=" -Dsonar.login=\"${sonar_login}\""
 fi
 
@@ -150,10 +147,10 @@ fi
 # "additional" property.
 additional_properties=$(jq -r '.params.additional_properties' < "${payload}")
 if [ ! -z "${additional_properties}" ]; then
-  read -r -a props_kv_arr <<< "$(jq -r 'to_entries|map("\(.key)=\"\(.value|tostring)\"")|.[]' <<< "${additional_properties}")"
-  for prop_kv in "${props_kv_arr[@]}"; do
-    scanner_opts+=" -D${prop_kv}"
-  done
+  while read -r name value; do
+      prop_kv="$name=\"$value\""
+      scanner_opts+=" -D${prop_kv}"
+  done < <(jq -r 'to_entries[] | "\(.key) \(.value)"' <<< "${additional_properties}")
 fi
 
 cd "${project_path}"


### PR DESCRIPTION
PR that now properly handles the `additional_properties` part of the payload. Before this PR, the part parsing out the additional properties would only take the first one (if 2 were sent in).  Now works well for analyzing golang code in the `out` repo including `coverage.xml`, `report.xml` and `tests.xml` when used as:

```
  - put: code-analysis
    params:
      project_path: out
      project_key: ((repo)):((branch))
      sources: "."
      additional_properties:
        sonar.inclusions: "**/**.go"
        sonar.projectName: ((repo))
```

Also removed the requirement on sonar.login seeing as you can have a SonarQube instance which does not require this (for example if you run the default deployment in a k8s cluster).