### PR TITLE
New `additional_properties_file` out-param

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ quality gate associated with a project are not met.
 * `additional_properties`: Optional object/dictionary that may contain any additional properties
   that one might want to pass when running the sonar-scanner.
 
+* `additional_properties_file`: Optional path to a file containing properties
+  that should be passed to the sonar-scanner.
+
 * `maven_settings_file`: Path to a Maven settings file that shall be used.
   Only used if the scanner_type during has been set to / determined to use Maven.
   If the resource itself has a maven_settings configuration, this key will override

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -36,7 +36,11 @@ function sanitize_base_url {
 # Reads a properties file and returns a list of variable assignments
 # that can be used to re-use these properties in a shell scripting environment.
 function read_properties {
-  awk -f "${root:?}/readproperties.awk" < "${1}"
+  if [[ "$2" == "shell" ]]; then
+    awk -f "${root:?}/readproperties.awk" -v sv=1  < "${1}"
+  else
+    awk -f "${root:?}/readproperties.awk" -v sv=0  < "${1}"
+  fi
 }
 
 # Checks on a compute engine task

--- a/assets/out
+++ b/assets/out
@@ -204,10 +204,10 @@ fi
 
 additional_properties_file=$(jq -r '.params.additional_properties_file // ""' < "${payload}")
 if [[ ! -z "${additional_properties_file}" ]]; then
-  while read p; do
-    p=$(echo "${p}" | sed -e '/=/s/=/="/' | sed -e 's/$/"/')
+  props=$(read_properties "${additional_properties_file}")
+  while read -r p; do
     scanner_opts+=" -D${p}"
-  done < "${additional_properties_file}"
+  done <<< "${props}"
 fi
 
 cd "${project_path}"
@@ -216,7 +216,7 @@ eval "${scanner_bin} ${scanner_opts}"
 
 echo "Reading SonarQube scanner report (${scanner_report_file})..."
 if [[ -f "${scanner_report_file}" ]]; then
-  eval "$(read_properties "${scanner_report_file}")"
+  eval "$(read_properties "${scanner_report_file}" "shell")"
   if [[ -z "${serverVersion:-}" ]]; then
     # Older versions of SonarQube don't store the serverVersion in
     # report-task.txt. There is a REST API though, that can be used

--- a/assets/out
+++ b/assets/out
@@ -202,6 +202,14 @@ if [[ ! -z "${additional_properties}" ]]; then
   done < <(jq -r 'to_entries[] | "\(.key) \(.value)"' <<< "${additional_properties}")
 fi
 
+additional_properties_file=$(jq -r '.params.additional_properties_file // ""' < "${payload}")
+if [[ ! -z "${additional_properties_file}" ]]; then
+  while read p; do
+    p=$(echo "${p}" | sed -e '/=/s/=/="/' | sed -e 's/$/"/')
+    scanner_opts+=" -D${p}"
+  done < "${additional_properties_file}"
+fi
+
 cd "${project_path}"
 echo "Starting sonar-scanner (type: ${scanner_type})..."
 eval "${scanner_bin} ${scanner_opts}"

--- a/assets/readproperties.awk
+++ b/assets/readproperties.awk
@@ -30,7 +30,9 @@ BEGIN {
         v= "" v $0;
     }
     # Make sure the name is a legal shell variable name
-    gsub(/[^A-Za-z0-9_]/,"_",n);
+    if (sv==1) {
+        gsub(/[^A-Za-z0-9_]/,"_",n);
+    }
     # Remove newlines from the value.
     gsub(/[\n\r]/,"",v);
     print n "=\"" v "\"";


### PR DESCRIPTION
This should help in situations where you have to set dynamic properties
for the scanner in a previous task. All these properties should then be
written to a single file which can then be used here.