### PR TITLE
Handling Sonar UserToken

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -35,9 +35,9 @@ sonar_login=$(jq -r '.source.login // ""' < "${payload}")
 sonar_password=$(jq -r '.source.password // ""' < "${payload}")
 
 if [[ ! -z "${sonar_login}" ]] && [[ "${sonar_login}" != "" ]]; then
-  sonar_token="${sonar_login}"
+  sonar_token="${sonar_login}:"
   if [[ ! -z "${sonar_password}" ]] && [[ "${sonar_password}" != "" ]]; then
-    sonar_token+=":${sonar_password}"
+    sonar_token+="${sonar_password}"
   fi
 fi
 


### PR DESCRIPTION
Fix for #31 

Here's the Sonarqube [documentation](https://docs.sonarqube.org/display/DEV/Web+API) for using UserToken. The curl command has to be like,

```
curl -u THIS_IS_MY_TOKEN: https://sonarqube.com/api/user_tokens/search
# note that the colon after the token is required in curl to set an empty password 
```