### PR TITLE
Error handling for the sonar task status

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -50,13 +50,19 @@ fi
 cd "${dest}"
 
 ce_task_info="./ce_task.json"
+ce_error="./ce_error"
 ce_task_status="PENDING"
 ce_task_error=""
-until [ "${ce_task_status}" != "PENDING" ] && [ "${ce_task_status}" != "IN_PROGRESS" ] && [ "${ce_task_status}" != "" ]; do
-  sq_ce_task "${sonar_token}" "${sonar_host_url}" "${ce_task_id}" > "${ce_task_info}"
+attempt=0
+max_attempts=2
+
+until [ "${ce_task_status}" != "PENDING" ] && [ "${ce_task_status}" != "IN_PROGRESS" ] && [ -n "${ce_task_status}" ]; do
+  attempt=$(( attempt + 1 ))
+  set +e
+  sq_ce_task "${sonar_token}" "${sonar_host_url}" "${ce_task_id}" > "${ce_task_info}" 2>"${ce_error}" || { ce_task_error=$(<"${ce_error}"); }
+  set -e
   ce_task_status=$(jq -r '.task.status // ""' < "${ce_task_info}")
-  ce_task_error=$(jq -r '.errors[0].msg // ""' < "${ce_task_info}")
-  if [[ "${ce_task_error}" != "" ]]; then
+  if [[ $attempt -gt $max_attempts ]] && [[ -z "${ce_task_status}" ]] ; then
     jq -n "{
       version: { ce_task_id: \"${ce_task_id}\"},
       metadata: [
@@ -65,8 +71,7 @@ until [ "${ce_task_status}" != "PENDING" ] && [ "${ce_task_status}" != "IN_PROGR
     }" >&3
     exit 1
   fi
-  ce_task_error=$(jq -r '.errors[0].msg // ""' < "${ce_task_info}")
-  if [[ "${ce_task_status}" != "PENDING" ]] && [[ "${ce_task_status}" != "IN_PROGRESS" ]] && [[ "${ce_task_status}" != "" ]]; then
+  if [[ "${ce_task_status}" != "PENDING" ]] && [[ "${ce_task_status}" != "IN_PROGRESS" ]]; then
     echo "Waiting for compute engine result (sleep: 5s)..."
     sleep 5 # Poll SonarQube compute engine task every 5 seconds.
   fi

--- a/assets/in
+++ b/assets/in
@@ -51,10 +51,22 @@ cd "${dest}"
 
 ce_task_info="./ce_task.json"
 ce_task_status="PENDING"
-until [ "${ce_task_status}" != "PENDING" ] && [ "${ce_task_status}" != "IN_PROGRESS" ]; do
+ce_task_error=""
+until [ "${ce_task_status}" != "PENDING" ] && [ "${ce_task_status}" != "IN_PROGRESS" ] && [ "${ce_task_status}" != "" ]; do
   sq_ce_task "${sonar_token}" "${sonar_host_url}" "${ce_task_id}" > "${ce_task_info}"
   ce_task_status=$(jq -r '.task.status // ""' < "${ce_task_info}")
-  if [[ "${ce_task_status}" != "PENDING" ]] && [[ "${ce_task_status}" != "IN_PROGRESS" ]]; then
+  ce_task_error=$(jq -r '.errors[0].msg // ""' < "${ce_task_info}")
+  if [[ "${ce_task_error}" != "" ]]; then
+    jq -n "{
+      version: { ce_task_id: \"${ce_task_id}\"},
+      metadata: [
+          { name: \"ce_task_status\", value: \"error: ${ce_task_error}\" }
+      ]
+    }" >&3
+    exit 1
+  fi
+  ce_task_error=$(jq -r '.errors[0].msg // ""' < "${ce_task_info}")
+  if [[ "${ce_task_status}" != "PENDING" ]] && [[ "${ce_task_status}" != "IN_PROGRESS" ]] && [[ "${ce_task_status}" != "" ]]; then
     echo "Waiting for compute engine result (sleep: 5s)..."
     sleep 5 # Poll SonarQube compute engine task every 5 seconds.
   fi


### PR DESCRIPTION
This is the fix for issue #33 when the cathive sonar resource fails silently if the curl command fails
when the curl command fails the resource should re-try and not fail immediately. 