### PR TITLE
Add support for project_key_file parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ quality gate associated with a project are not met.
 
 * `project_key`: Project key (default value is read from sonar-project.properties)
 
+* `project_key_file`: File to be used to read the Project key.
+  When this option has been specified, it has precedence over the `project_key` parameter.
+
 * `project_name`: Project name (default value is read from sonar-project.properties)
 
 * `project_description`: Project description (default value is read from sonar-project.properties)

--- a/assets/out
+++ b/assets/out
@@ -94,6 +94,17 @@ if [[ ! -z "${sonar_project_key}" ]]; then
 	scanner_opts+=" -Dsonar.projectKey=\"${sonar_project_key}\""
 fi
 
+sonar_project_key_file=$(jq -r '.params.project_key_file // ""' < "${payload}")
+if [[ ! -z "${sonar_project_key_file}" ]]; then
+	if [[ ! -f "${sonar_project_key_file}" ]]; then
+		echo "error: Project key file not found: ${sonar_project_key_file}"
+		exit 1
+	else
+		sonar_project_key=$(cat "${sonar_project_key_file}")
+		scanner_opts+=" -Dsonar.projectKey=\"${sonar_project_key}\""
+	fi
+fi
+
 sonar_project_name=$(jq -r '.params.project_name // ""' < "${payload}")
 if [[ ! -z "${sonar_project_name}" ]]; then
 	scanner_opts+=" -Dsonar.projectName=\"${sonar_project_name}\""


### PR DESCRIPTION
## Why?
We use the [Bitbucket PR resource](https://github.com/zarplata/concourse-git-bitbucket-pr-resource) to run Sonar analysis on each pull requests.
We do not use the Sonar multi-branching feature so we need to compute a new Sonar project key for every pull requests.
The Sonar project key is available in a file and not in a static variables

## What?
We add the parameter `project_key_file` to achieve this goal.
It works exactly like the `project_version_file` parameter.