### PR TITLE
Add support for convert wildcards to comma-separated paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ quality gate associated with a project are not met.
 
 * `sonar_maven_plugin_version`: sonar-maven-plugin version (default is empty and using the latest version)
 
+#### Wildcards Support
+
+Support convert wildcards to comma-separated paths.
+
+* `sources`
+* `tests`
+* `sonar.jacoco.reportPaths` in `additional_properties`
+
 ### in: Fetch result of SonarQube analysis
 
 The action will place two JSON files into the resource's folder which are fetched from

--- a/assets/check
+++ b/assets/check
@@ -17,7 +17,7 @@ DEBUG="$(jq -r '.source.__debug // "false"' < "${payload}")"
 enable_debugging "${DEBUG}"
 
 latest_version=$(jq -r '.version.ce_task_id // ""' < "${payload}")
-if [[ ! -z "${latest_version}" ]]; then
+if [[ -n "${latest_version}" ]]; then
 	jq -n "[
 		{ ce_task_id: \"${latest_version}\"}
 	]" >&3

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -211,7 +211,7 @@ function wildcardConvert {
     for wildcard in $wildcards; do
         for w in $wildcard; do
             if [ "$( wildcardExists "$w" )" -ne "0" ]; then
-                echo "path [$w] not exit"
+                echo "path [$w] not found under $(pwd)"
                 return 1;
             fi
             convert_res+="$w,"

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -185,6 +185,7 @@ function wildcardExists {
 # Convert wildcards to comma-separated paths
 # $1 param_key: sonar parameter key
 # $2 wildcards: potential wildcard string
+# $3 project_path: params.project_path
 function wildcardConvert {
     SUPPORT_PARAMS=(
         sonar.sources
@@ -193,6 +194,7 @@ function wildcardConvert {
     )
     local param_key="$1"
     local wildcards="$2"
+    local project_path="$3"
 
     # check if $wildcards is a wildcard string
     if [ "$wildcards" == "${wildcards//[\[\]|.? +*]/}" ] ; then
@@ -209,12 +211,13 @@ function wildcardConvert {
     convert_res=""
     IFS=',';
     for wildcard in $wildcards; do
-        for w in $wildcard; do
+        for w in ${project_path}/$wildcard; do
             if [ "$( wildcardExists "$w" )" -ne "0" ]; then
                 echo "path [$w] not found under $(pwd)"
                 return 1;
             fi
-            convert_res+="$w,"
+            # remove prefix "${project_path}/" since following step contains "cd $project_path/"
+            convert_res+="${w/#${project_path}\/},"
         done
     done; unset IFS;
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -169,7 +169,7 @@ function contains {
 
 # return "0" if $1 is exist
 # return "1" if $1 not exist
-function wildcardExists {
+function wildcard_exists {
     local wildcards="$1"
 
     for f in $wildcards; do
@@ -186,7 +186,7 @@ function wildcardExists {
 # $1 param_key: sonar parameter key
 # $2 wildcards: potential wildcard string
 # $3 project_path: params.project_path
-function wildcardConvert {
+function wildcard_convert {
     SUPPORT_PARAMS=(
         sonar.sources
         sonar.tests
@@ -212,7 +212,7 @@ function wildcardConvert {
     IFS=',';
     for wildcard in $wildcards; do
         for w in ${project_path}/$wildcard; do
-            if [ "$( wildcardExists "$w" )" -ne "0" ]; then
+            if [ "$( wildcard_exists "$w" )" -ne "0" ]; then
                 echo "path [$w] not found under $(pwd)"
                 return 1;
             fi

--- a/assets/in
+++ b/assets/in
@@ -38,9 +38,9 @@ sonar_login=$(jq -r '.source.login // ""' < "${payload}")
 
 sonar_password=$(jq -r '.source.password // ""' < "${payload}")
 
-if [[ ! -z "${sonar_login}" ]] && [[ "${sonar_login}" != "" ]]; then
+if [[ -n "${sonar_login}" ]] && [[ "${sonar_login}" != "" ]]; then
 	sonar_token="${sonar_login}:"
-	if [[ ! -z "${sonar_password}" ]] && [[ "${sonar_password}" != "" ]]; then
+	if [[ -n "${sonar_password}" ]] && [[ "${sonar_password}" != "" ]]; then
 		sonar_token+="${sonar_password}"
 	fi
 fi

--- a/assets/out
+++ b/assets/out
@@ -159,11 +159,13 @@ fi
 
 sonar_sources=$(jq -r '.params.sources // [] | join(",")' < "${payload}")
 if [[ ! -z "${sonar_sources}" ]]; then
+	sonar_sources=$(wildcardConvert "sonar.sources" "${sonar_sources}")
 	scanner_opts+=" -Dsonar.sources=\"${sonar_sources}\""
 fi
 
 sonar_tests=$(jq -r '.params.tests // [] | join(",")' < "${payload}")
 if [[ ! -z "${sonar_tests}" ]]; then
+	sonar_tests=$(wildcardConvert "sonar.tests" "${sonar_tests}")
 	scanner_opts+=" -Dsonar.tests=\"${sonar_tests}\""
 fi
 
@@ -221,6 +223,7 @@ fi
 additional_properties=$(jq -r '.params.additional_properties // ""' < "${payload}")
 if [[ ! -z "${additional_properties}" ]]; then
 	while read -r name value; do
+		value=$(wildcardConvert "${name}" "${value}")
 		prop_kv="$name=\"$value\""
 		scanner_opts+=" -D${prop_kv}"
 	done < <(jq -r 'to_entries[] | "\(.key) \(.value)"' <<< "${additional_properties}")

--- a/assets/out
+++ b/assets/out
@@ -160,7 +160,7 @@ fi
 sonar_sources=$(jq -r '.params.sources // [] | join(",")' < "${payload}")
 if [[ -n "${sonar_sources}" ]]; then
 	if ! sonar_sources=$(wildcardConvert "sonar.sources" "${sonar_sources}"); then
-		echo "error: $sonar_tests."
+		echo "error: while setting params.sources, $sonar_sources."
 		exit 1
 	fi
 	scanner_opts+=" -Dsonar.sources=\"${sonar_sources}\""
@@ -169,7 +169,7 @@ fi
 sonar_tests=$(jq -r '.params.tests // [] | join(",")' < "${payload}")
 if [[ -n "${sonar_tests}" ]]; then
 	if ! sonar_tests=$(wildcardConvert "sonar.tests" "${sonar_tests}"); then
-		echo "error: $sonar_tests."
+		echo "error: while setting params.tests, $sonar_tests."
 		exit 1
 	fi
 	scanner_opts+=" -Dsonar.tests=\"${sonar_tests}\""
@@ -230,7 +230,7 @@ additional_properties=$(jq -r '.params.additional_properties // ""' < "${payload
 if [[ -n "${additional_properties}" ]]; then
 	while read -r name value; do
 		if ! value=$(wildcardConvert "${name}" "${value}"); then
-			echo "error: $value."
+			echo "error: while setting additional_properties.$name, $value."
 			exit 1
 		fi
 		prop_kv="$name=\"$value\""

--- a/assets/out
+++ b/assets/out
@@ -53,17 +53,17 @@ scanner_opts+=" -Dsonar.host.url=${sonar_host_url}"
 
 
 sonar_organization=$(jq -r '.source.organization // ""' < "${payload}")
-if [[ ! -z "${sonar_organization}" ]]; then
+if [[ -n "${sonar_organization}" ]]; then
 	scanner_opts+=" -Dsonar.organization=\"${sonar_organization}\""
 fi
 
 sonar_login=$(jq -r '.source.login // ""' < "${payload}")
-if [[ ! -z "${sonar_login}" ]]; then
+if [[ -n "${sonar_login}" ]]; then
 	scanner_opts+=" -Dsonar.login=\"${sonar_login}\""
 fi
 
 sonar_password=$(jq -r '.source.password // ""' < "${payload}")
-if [[ ! -z "${sonar_password}" ]]; then
+if [[ -n "${sonar_password}" ]]; then
 	scanner_opts+=" -Dsonar.password=\"${sonar_password}\""
 fi
 
@@ -71,7 +71,7 @@ fi
 # If they have been defined inline, they take precedence over a possibly specified
 # maven settings file.
 maven_settings=$(jq -r '.source.maven_settings // ""' < "${payload}")
-if [[ ! -z "${maven_settings}" ]]; then
+if [[ -n "${maven_settings}" ]]; then
 	maven_settings_file=$(mktemp "${TMPDIR}/sonarqube-resource-maven-settings.xml.XXXXXX")
 	echo "${maven_settings}" > "${maven_settings_file}"
 	unset maven_settings
@@ -79,7 +79,7 @@ else
 	maven_settings_file=$(jq -r '.params.maven_settings_file // ""' < "${payload}")
 fi
 
-if [[ ! -z "${maven_settings_file}" ]]; then
+if [[ -n "${maven_settings_file}" ]]; then
 	if [[ ! -f "${maven_settings_file}" ]]; then
 		echo "error: Maven settings file not found: \"${maven_settings_file}\"."
 		exit 1
@@ -90,12 +90,12 @@ if [[ ! -z "${maven_settings_file}" ]]; then
 fi
 
 sonar_project_key=$(jq -r '.params.project_key // ""' < "${payload}")
-if [[ ! -z "${sonar_project_key}" ]]; then
+if [[ -n "${sonar_project_key}" ]]; then
 	scanner_opts+=" -Dsonar.projectKey=\"${sonar_project_key}\""
 fi
 
 sonar_project_key_file=$(jq -r '.params.project_key_file // ""' < "${payload}")
-if [[ ! -z "${sonar_project_key_file}" ]]; then
+if [[ -n "${sonar_project_key_file}" ]]; then
 	if [[ ! -f "${sonar_project_key_file}" ]]; then
 		echo "error: Project key file not found: ${sonar_project_key_file}"
 		exit 1
@@ -106,22 +106,22 @@ if [[ ! -z "${sonar_project_key_file}" ]]; then
 fi
 
 sonar_project_name=$(jq -r '.params.project_name // ""' < "${payload}")
-if [[ ! -z "${sonar_project_name}" ]]; then
+if [[ -n "${sonar_project_name}" ]]; then
 	scanner_opts+=" -Dsonar.projectName=\"${sonar_project_name}\""
 fi
 
 sonar_project_description=$(jq -r '.params.project_description // ""' < "${payload}")
-if [[ ! -z "${sonar_project_description}" ]]; then
+if [[ -n "${sonar_project_description}" ]]; then
 	scanner_opts+=" -Dsonar.projectDescription=\"${sonar_project_description}\""
 fi
 
 sonar_project_version=$(jq -r '.params.project_version // ""' < "${payload}")
-if [[ ! -z "${sonar_project_version}" ]]; then
+if [[ -n "${sonar_project_version}" ]]; then
 	scanner_opts+=" -Dsonar.projectVersion=\"${sonar_project_version}\""
 fi
 
 sonar_project_version_file=$(jq -r '.params.project_version_file // ""' < "${payload}")
-if [[ ! -z "${sonar_project_version_file}" ]]; then
+if [[ -n "${sonar_project_version_file}" ]]; then
 	if [[ ! -f "${sonar_project_version_file}" ]]; then
 		echo "error: Version file not found: ${sonar_project_version_file}"
 		exit 1
@@ -148,24 +148,30 @@ fi
 # So... if the branch name has been either specified manually or we have been able
 # to figure it out automatically using our SCM tools, we can pass sonar.branch.name
 # to the sonar-scanner. Yay!!
-if [[ ! -z "${sonar_branch_name}" ]]; then
+if [[ -n "${sonar_branch_name}" ]]; then
 	scanner_opts+=" -Dsonar.branch.name=\"${sonar_branch_name}\""
 fi
 
 sonar_branch_target=$(jq -r '.params.branch_target // ""' < "${payload}")
-if [[ ! -z "${sonar_branch_target}" ]]; then
+if [[ -n "${sonar_branch_target}" ]]; then
 	scanner_opts+=" -Dsonar.branch.target=\"${sonar_branch_target}\""
 fi
 
 sonar_sources=$(jq -r '.params.sources // [] | join(",")' < "${payload}")
-if [[ ! -z "${sonar_sources}" ]]; then
-	sonar_sources=$(wildcardConvert "sonar.sources" "${sonar_sources}")
+if [[ -n "${sonar_sources}" ]]; then
+	if ! sonar_sources=$(wildcardConvert "sonar.sources" "${sonar_sources}"); then
+		echo "error: $sonar_tests."
+		exit 1
+	fi
 	scanner_opts+=" -Dsonar.sources=\"${sonar_sources}\""
 fi
 
 sonar_tests=$(jq -r '.params.tests // [] | join(",")' < "${payload}")
-if [[ ! -z "${sonar_tests}" ]]; then
-	sonar_tests=$(wildcardConvert "sonar.tests" "${sonar_tests}")
+if [[ -n "${sonar_tests}" ]]; then
+	if ! sonar_tests=$(wildcardConvert "sonar.tests" "${sonar_tests}"); then
+		echo "error: $sonar_tests."
+		exit 1
+	fi
 	scanner_opts+=" -Dsonar.tests=\"${sonar_tests}\""
 fi
 
@@ -193,7 +199,7 @@ elif [[ "${scanner_type}" == "maven" ]]; then
 	if [[ "${DEBUG}" == "true" ]]; then
 		mvn+=" -X"
 	fi
-	if [[ ! -z "${maven_settings_file}" ]]; then
+	if [[ -n "${maven_settings_file}" ]]; then
 		mvn+=" -s ${maven_settings_file}"
 	fi
 
@@ -203,7 +209,7 @@ elif [[ "${scanner_type}" == "maven" ]]; then
 	fi
 
 	sonar_maven_plugin_version=$(jq -r '.params.sonar_maven_plugin_version // ""' < "${payload}")
-	if [[ ! -z "${sonar_maven_plugin_version}" ]]; then
+	if [[ -n "${sonar_maven_plugin_version}" ]]; then
 		scanner_bin="${scanner_bin} org.sonarsource.scanner.maven:sonar-maven-plugin:${sonar_maven_plugin_version}:sonar"
 	else
 		# Default using the latest version of sonar-maven-plugin
@@ -221,16 +227,19 @@ fi
 # the fact that some "basic" properties might have specified a second time as
 # "additional" property.
 additional_properties=$(jq -r '.params.additional_properties // ""' < "${payload}")
-if [[ ! -z "${additional_properties}" ]]; then
+if [[ -n "${additional_properties}" ]]; then
 	while read -r name value; do
-		value=$(wildcardConvert "${name}" "${value}")
+		if ! value=$(wildcardConvert "${name}" "${value}"); then
+			echo "error: $value."
+			exit 1
+		fi
 		prop_kv="$name=\"$value\""
 		scanner_opts+=" -D${prop_kv}"
 	done < <(jq -r 'to_entries[] | "\(.key) \(.value)"' <<< "${additional_properties}")
 fi
 
 additional_properties_file=$(jq -r '.params.additional_properties_file // ""' < "${payload}")
-if [[ ! -z "${additional_properties_file}" ]]; then
+if [[ -n "${additional_properties_file}" ]]; then
 	props=$(read_properties "${additional_properties_file}")
 	while read -r p; do
 		scanner_opts+=" -D${p}"
@@ -249,9 +258,9 @@ if [[ -f "${scanner_report_file}" ]]; then
 		# report-task.txt. There is a REST API though, that can be used
 		# to fetch the version.
 		sonar_token=""
-		if [[ ! -z "${sonar_login}" ]] && [[ "${sonar_login}" != "" ]]; then
+		if [[ -n "${sonar_login}" ]] && [[ "${sonar_login}" != "" ]]; then
 			sonar_token="${sonar_login}"
-			if [[ ! -z "${sonar_password}" ]] && [[ "${sonar_password}" != "" ]]; then
+			if [[ -n "${sonar_password}" ]] && [[ "${sonar_password}" != "" ]]; then
 				sonar_token+=":${sonar_password}"
 			fi
 		fi

--- a/assets/out
+++ b/assets/out
@@ -159,7 +159,7 @@ fi
 
 sonar_sources=$(jq -r '.params.sources // [] | join(",")' < "${payload}")
 if [[ -n "${sonar_sources}" ]]; then
-	if ! sonar_sources=$(wildcardConvert "sonar.sources" "${sonar_sources}"); then
+	if ! sonar_sources=$(wildcardConvert "sonar.sources" "${sonar_sources}" "${project_path}"); then
 		echo "error: while setting params.sources, $sonar_sources."
 		exit 1
 	fi
@@ -168,7 +168,7 @@ fi
 
 sonar_tests=$(jq -r '.params.tests // [] | join(",")' < "${payload}")
 if [[ -n "${sonar_tests}" ]]; then
-	if ! sonar_tests=$(wildcardConvert "sonar.tests" "${sonar_tests}"); then
+	if ! sonar_tests=$(wildcardConvert "sonar.tests" "${sonar_tests}" "${project_path}"); then
 		echo "error: while setting params.tests, $sonar_tests."
 		exit 1
 	fi
@@ -229,7 +229,7 @@ fi
 additional_properties=$(jq -r '.params.additional_properties // ""' < "${payload}")
 if [[ -n "${additional_properties}" ]]; then
 	while read -r name value; do
-		if ! value=$(wildcardConvert "${name}" "${value}"); then
+		if ! value=$(wildcardConvert "${name}" "${value}" "${project_path}"); then
 			echo "error: while setting additional_properties.$name, $value."
 			exit 1
 		fi

--- a/assets/out
+++ b/assets/out
@@ -159,7 +159,7 @@ fi
 
 sonar_sources=$(jq -r '.params.sources // [] | join(",")' < "${payload}")
 if [[ -n "${sonar_sources}" ]]; then
-	if ! sonar_sources=$(wildcardConvert "sonar.sources" "${sonar_sources}" "${project_path}"); then
+	if ! sonar_sources=$(wildcard_convert "sonar.sources" "${sonar_sources}" "${project_path}"); then
 		echo "error: while setting params.sources, $sonar_sources."
 		exit 1
 	fi
@@ -168,7 +168,7 @@ fi
 
 sonar_tests=$(jq -r '.params.tests // [] | join(",")' < "${payload}")
 if [[ -n "${sonar_tests}" ]]; then
-	if ! sonar_tests=$(wildcardConvert "sonar.tests" "${sonar_tests}" "${project_path}"); then
+	if ! sonar_tests=$(wildcard_convert "sonar.tests" "${sonar_tests}" "${project_path}"); then
 		echo "error: while setting params.tests, $sonar_tests."
 		exit 1
 	fi
@@ -229,7 +229,7 @@ fi
 additional_properties=$(jq -r '.params.additional_properties // ""' < "${payload}")
 if [[ -n "${additional_properties}" ]]; then
 	while read -r name value; do
-		if ! value=$(wildcardConvert "${name}" "${value}" "${project_path}"); then
+		if ! value=$(wildcard_convert "${name}" "${value}" "${project_path}"); then
 			echo "error: while setting additional_properties.$name, $value."
 			exit 1
 		fi


### PR DESCRIPTION
Support wildcards convert to comma-separated paths:
* `sources`
* `tests`
* `sonar.jacoco.reportPaths` in `additional_properties`
