### PR TITLE
Warning about path not exist, instead of fail/block the build.

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -213,8 +213,8 @@ function wildcard_convert {
     for wildcard in $wildcards; do
         for w in ${project_path}/$wildcard; do
             if [ "$( wildcard_exists "$w" )" -ne "0" ]; then
-                echo "path [$w] not found under $(pwd)"
-                return 1;
+                # Warning about path not exist, instead of fail/block the build.
+                echo "Warning: path [$w] not exit under $(pwd)" >&2
             fi
             # remove prefix "${project_path}/" since following step contains "cd $project_path/"
             convert_res+="${w/#${project_path}\/},"


### PR DESCRIPTION
if the path does not exist, rather than fail/block the build, it can pass the same str as is with wildcards.
Sonar runner will still process other metrics like bugs, code smells, vulnerabilities, duplications etc.
```
INFO: Sensor JaCoCoSensor [java]
13:11:11
INFO: JaCoCo report not found: '**/build/jacoco/test.exec'
13:11:11
INFO: Sensor JaCoCoSensor [java] (done) | time=1ms
```
It will push code coverage metric as 0% - this can later be gated based on vmc policy (coverage >70%)