### PR TITLE
add metadata as qualitygates project status conditions

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -223,3 +223,13 @@ function wildcard_convert {
 
     echo "${convert_res/%,/}"
 }
+
+
+# Generate metadata from conditions
+# $1 qg_status_path: quality_gate status file
+function metadata_from_conditions {
+    local qg_status_path="$1"
+
+    conditions=$(jq -r ".projectStatus.conditions // []" < $qg_status_path)    
+    echo $conditions | jq -r 'map({"name": .metricKey, "value": .actualValue})'
+}

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -230,6 +230,6 @@ function wildcard_convert {
 function metadata_from_conditions {
     local qg_status_path="$1"
 
-    conditions=$(jq -r ".projectStatus.conditions // []" < $qg_status_path)    
-    echo $conditions | jq -r 'map({"name": .metricKey, "value": .actualValue})'
+    conditions=$(jq -r ".projectStatus.conditions // []" < "$qg_status_path")
+    echo "$conditions" | jq -r 'map({"name": .metricKey, "value": .actualValue})'
 }

--- a/assets/in
+++ b/assets/in
@@ -98,7 +98,10 @@ if [[ -n "${quality_gate}" ]]; then
 	parse_quality_gates "${quality_gate}" "${project_status}"
 fi
 
+metadata=$(metadata_from_conditions $project_status)
 project_status=$(jq -r '.projectStatus.status // ""' < "${project_status}")
+
+
 
 jq -n "{
 	version: { ce_task_id: \"${ce_task_id}\"},
@@ -106,4 +109,4 @@ jq -n "{
 		{ name: \"ce_task_status\", value: \"${ce_task_status}\" },
 		{ name: \"project_status\", value: \"${project_status}\" }
 	]
-}" >&3
+}" | jq --argjson m "$metadata" -r '.metadata += $m' >&3

--- a/test/mocks/qualitygates_project_status.json
+++ b/test/mocks/qualitygates_project_status.json
@@ -1,0 +1,69 @@
+{
+    "projectStatus": {
+      "status": "ERROR",
+      "ignoredConditions": false,
+      "conditions": [
+        {
+          "status": "ERROR",
+          "metricKey": "new_coverage",
+          "comparator": "LT",
+          "periodIndex": 1,
+          "errorThreshold": "85",
+          "actualValue": "82.50562381034781"
+        },
+        {
+          "status": "ERROR",
+          "metricKey": "new_blocker_violations",
+          "comparator": "GT",
+          "periodIndex": 1,
+          "errorThreshold": "0",
+          "actualValue": "14"
+        },
+        {
+          "status": "ERROR",
+          "metricKey": "new_critical_violations",
+          "comparator": "GT",
+          "periodIndex": 1,
+          "errorThreshold": "0",
+          "actualValue": "1"
+        },
+        {
+          "status": "OK",
+          "metricKey": "new_sqale_debt_ratio",
+          "comparator": "GT",
+          "periodIndex": 1,
+          "errorThreshold": "5",
+          "actualValue": "0.6562109862671661"
+        },
+        {
+          "status": "OK",
+          "metricKey": "reopened_issues",
+          "comparator": "GT",
+          "periodIndex": 1,
+          "actualValue": "0"
+        },
+        {
+          "status": "ERROR",
+          "metricKey": "open_issues",
+          "comparator": "GT",
+          "periodIndex": 1,
+          "actualValue": "17"
+        },
+        {
+          "status": "OK",
+          "metricKey": "skipped_tests",
+          "comparator": "GT",
+          "periodIndex": 1,
+          "actualValue": "0"
+        }
+      ],
+      "periods": [
+        {
+          "index": 1,
+          "mode": "last_version",
+          "date": "2000-04-27T00:45:23+0200",
+          "parameter": "2015-12-07"
+        }
+      ]
+    }
+  }

--- a/test_common.sh
+++ b/test_common.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source assets/common.sh
+
+project_status="test/mocks/qualitygates_project_status.json"
+metadata=$(metadata_from_conditions $project_status)
+echo $metadata
+


### PR DESCRIPTION
example more output metadata: 
```json
    {
      "name": "new_coverage",
      "value": "82.50562381034781"
    },
    {
      "name": "new_blocker_violations",
      "value": "14"
    },
    {
      "name": "new_critical_violations",
      "value": "1"
    },
    {
      "name": "new_sqale_debt_ratio",
      "value": "0.6562109862671661"
    },
    {
      "name": "reopened_issues",
      "value": "0"
    },
    {
      "name": "open_issues",
      "value": "17"
    },
    {
      "name": "skipped_tests",
      "value": "0"
    }
```