### PR TITLE
Broaden Scope of Wildcard Path Support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@
 * Rekha Mittal &lt;rekha.mittal@calculi.com&gt;
 * Rune Engseth &lt;rune.engseth@tine.no&gt;
 * Ye Yang &lt;yangye@vmware.com&gt;
+* Greg Carter &lt;greg_carter@comcast.com&gt;
 
 ## Third party components
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2019-08-19
+
+### Added
+
+- Improved support for wildcard path arguments for properties
+ending with `*reportPaths`. Corrected some documentation.
+  
 ## [0.9.0] - 2019-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add a new resource type to your Concourse CI pipeline:
 The resource implements all three actions (check, in and out).
 The analysis is triggered by the out action and check/in will be used to wait for
 the result of the analysis and pull in the project status. Tasks can use this
-information to break the build (if desired) if any of the criterias of the
+information to break the build (if desired) if any of the criteria of the
 quality gate associated with a project are not met.
 
 ### out: Trigger SonarQube analysis
@@ -124,7 +124,7 @@ Support convert wildcards to comma-separated paths.
 
 * `sources`
 * `tests`
-* `sonar.jacoco.reportPaths` in `additional_properties`
+* Any key with the suffix `.reportPaths` in `additional_properties`
 
 ### in: Fetch result of SonarQube analysis
 
@@ -183,7 +183,6 @@ resources:
   source:
     host_url: https://sonarqube.example.com/
     login: ((sonarqube-auth-token))
-    project_key: com.example.my_project
 
 jobs:
 
@@ -223,6 +222,9 @@ jobs:
     - put: code-analysis
       params:
         project_path: sonarqube-analysis-input
+        project_key: com.example.my_project
+        sources: ["."]
+        tests: ["."]
         additional_properties:
           # Will be passed as "-Dsonar.javascript.lcov.reportPaths="coverage/lcov.info" to the scanner.
           sonar.javascript.lcov.reportPaths: coverage/lcov.info

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -190,7 +190,6 @@ function wildcard_convert {
     SUPPORT_PARAMS=(
         sonar.sources
         sonar.tests
-        sonar.jacoco.reportPaths
     )
     local param_key="$1"
     local wildcards="$2"
@@ -203,9 +202,11 @@ function wildcard_convert {
     fi
 
     # check if request $param_key is supported
-    if [ "$( contains "${SUPPORT_PARAMS[*]}" "$param_key" )" -ne "0" ]; then
-        echo "$wildcards";
-        return 0;
+    if [[ "$param_key" != *".reportPaths" ]]; then
+        if [ "$( contains "${SUPPORT_PARAMS[*]}" "$param_key" )" -ne "0" ]; then
+            echo "$wildcards";
+            return 0;
+        fi
     fi
 
     convert_res=""
@@ -214,7 +215,7 @@ function wildcard_convert {
         for w in ${project_path}/$wildcard; do
             if [ "$( wildcard_exists "$w" )" -ne "0" ]; then
                 # Warning about path not exist, instead of fail/block the build.
-                echo "Warning: path [$w] not exit under $(pwd)" >&2
+                echo "Warning: path [$w] does not exist under $(pwd)" >&2
             fi
             # remove prefix "${project_path}/" since following step contains "cd $project_path/"
             convert_res+="${w/#${project_path}\/},"


### PR DESCRIPTION
Broaden scope of wildcard path support (properties ending with `.reportPaths`) on output. And a few doc corrections.

With this change I'm able to use this Concourse resource type with my Go projects. In particular, this now works for key `sonar.go.coverage.reportPaths`:
```
  - put: code-analysis
    params:
      project_path: ((dev_branch))
      project_key: "((sonarqube_team)).((component))"
      sources: ["."]
      tests: ["."]
      additional_properties:
        # Will be passed as "-Dsonar.go.govet.reportPaths="../app/govet.out" to the scanner.
        sonar.go.govet.reportPaths: "../app/govet.out"
        sonar.go.golint.reportPaths: "../app/golint.out"
        sonar.go.tests.reportPaths: "../app/gotest.out"
        sonar.go.coverage.reportPaths: "../app/*_coverage.out"

        #https://docs.sonarqube.org/latest/analysis/languages/go/
        sonar.exclusions: "**/*_test.go,**/vendor/**"
        sonar.test.inclusions: "**/*_test.go"
        sonar.test.exclusions: "**/vendor/**"
```