### PR TITLE
Assing project status file to readonly variable

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -90,16 +90,16 @@ if [[ "${ce_task_status}" == "SUCCESS" ]]; then
 	fi
 fi
 
-project_status="./qualitygate_project_status.json"
-sq_qualitygates_project_status "${sonar_token}" "${sonar_host_url}" "${analysis_id}" > "${project_status}"
+project_status_file="./qualitygate_project_status.json"
+sq_qualitygates_project_status "${sonar_token}" "${sonar_host_url}" "${analysis_id}" > "${project_status_file}"
 
 quality_gate=$(jq -r '.params.quality_gate // ""' < "${payload}")
 if [[ -n "${quality_gate}" ]]; then
-	parse_quality_gates "${quality_gate}" "${project_status}"
+	parse_quality_gates "${quality_gate}" "${project_status_file}"
 fi
 
-metadata=$(metadata_from_conditions $project_status)
-project_status=$(jq -r '.projectStatus.status // ""' < "${project_status}")
+metadata=$(metadata_from_conditions $project_status_file)
+project_status=$(jq -r '.projectStatus.status // ""' < "${project_status_file}")
 
 
 


### PR DESCRIPTION
With the original version I was having the following issue:

```
Waiting for compute engine result (sleep: 5s)...
Start parseing quality_gates...
/opt/resource/common.sh: line 234: OK: No such file or directory
/opt/resource/in: line 102: OK: No such file or directory
ERROR in /opt/resource/in : line 102 with exit code 1
```

I think would be safe to have a readonly variable for project status file. In my tests it fixed my issue.