### PR TITLE
Add PR decoration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ quality gate associated with a project are not met.
   (See [Branch Plugin documentation](https://docs.sonarqube.org/display/PLUG/Branch+Plugin) for further
   details)
 
+* `decorate_pr`: If set to `true` it will try to fetch the pull request id and the head branch name from
+the pull request resource. It works for `telia-oss/github-pr-resource` and `jtarchie/github-pullrequest-resource`. It will enable `sonar.pullrequest.key` and `sonar.pullrequest.branch` flags when performing your analysis.
+  
+  >_In order to use this feature you must be using `SonarCloud` or `SonarQube Developer` edition._
+
 * `sources`: A list of paths to directories containing source files.
 
 * `tests`: A list of paths to directories containing source files.

--- a/assets/out
+++ b/assets/out
@@ -160,15 +160,15 @@ fi
 decorate_pr=$(jq -r '.params.decorate_pr // ""' < "${payload}")
 if [[ -n "${decorate_pr}" ]]; then
 	if [ -f "${project_path}/.git/resource/metadata.json" ]; then
-		pr_id=$( jq -r '.pr' ${project_path}/.git/resource/version.json )
-		branch_name=$( jq -r '.[] | select (.name == "head_name") | .value' ${project_path}/.git/resource/metadata.json )
+		pr_id=$( jq -r '.pr' "${project_path}/.git/resource/version.json" )
+		branch_name=$( jq -r '.[] | select (.name == "head_name") | .value' "${project_path}/.git/resource/metadata.json" )
 	else
 		pr_id=$(git config --get pullrequest.id)
 		branch_name=$(git config --get pullrequest.branch)
 	fi
 
-	scanner_opts+=" -Dsonar.pullrequest.key=\"${pr_id}\" -Dsonar.pullrequest.branch=${branch_name}"
-	echo "Decorating PR: \"${pr_id}\" for branch ${branch_name}"
+	scanner_opts+=" -Dsonar.pullrequest.key=${pr_id} -Dsonar.pullrequest.branch=${branch_name}"
+	echo "Decorating PR: ${pr_id} for branch ${branch_name}"
 fi
 
 sonar_sources=$(jq -r '.params.sources // [] | join(",")' < "${payload}")

--- a/assets/out
+++ b/assets/out
@@ -136,7 +136,7 @@ if [[ -z "${sonar_branch_name}" ]]; then
 	# If the branch name has NOT been specified, we'll check if autodetect_branch_name
 	# has been set to true and try to figure figure the branch out by using installed
 	# SCM tools.
-	autodetect_branch_name=$(jq -r '.params.autodetect_branch_name // "false"')
+	autodetect_branch_name=$(jq -r '.params.autodetect_branch_name // "false"' < "${payload}")
 	if [[ "${autodetect_branch_name}" == "true" ]]; then
 		echo "Trying to detect branch name automatically..."
 		if [[ -d "${project_path}/.git" ]]; then

--- a/assets/out
+++ b/assets/out
@@ -157,6 +157,20 @@ if [[ -n "${sonar_branch_target}" ]]; then
 	scanner_opts+=" -Dsonar.branch.target=\"${sonar_branch_target}\""
 fi
 
+decorate_pr=$(jq -r '.params.decorate_pr // ""' < "${payload}")
+if [[ -n "${decorate_pr}" ]]; then
+	if [ -f "${project_path}/.git/resource/metadata.json" ]; then
+		pr_id=$( jq -r '.pr' ${project_path}/.git/resource/version.json )
+		branch_name=$( jq -r '.[] | select (.name == "head_name") | .value' ${project_path}/.git/resource/metadata.json )
+	else
+		pr_id=$(git config --get pullrequest.id)
+		branch_name=$(git config --get pullrequest.branch)
+	fi
+
+	scanner_opts+=" -Dsonar.pullrequest.key=\"${pr_id}\" -Dsonar.pullrequest.branch=${branch_name}"
+	echo "Decorating PR: \"${pr_id}\" for branch ${branch_name}"
+fi
+
 sonar_sources=$(jq -r '.params.sources // [] | join(",")' < "${payload}")
 if [[ -n "${sonar_sources}" ]]; then
 	if ! sonar_sources=$(wildcard_convert "sonar.sources" "${sonar_sources}" "${project_path}"); then


### PR DESCRIPTION
We are using SonarCloud and, in order to decorate our PRs, we missed this feature in the resource. This PRs aims to add support for PR decoration if the user is using SonarCloud and probably will work with Developer Edition. We could use the resource as is but would be very trick to create custom sonar-project.properties file containing the branch name and PR