### PR TITLE
Add support for pr decoration on bitbucket pr resources.

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -186,6 +186,9 @@ if [[ -n "${decorate_pr}" ]]; then
 	if [ -f "${project_path}/.git/resource/metadata.json" ]; then
 		pr_id=$( jq -r '.pr' "${project_path}/.git/resource/version.json" )
 		branch_name=$( jq -r '.[] | select (.name == "head_name") | .value' "${project_path}/.git/resource/metadata.json" )
+	elif [ -f "${project_path}/pull-request-info" ]; then
+		pr_id=$( jq -r '.id' "${project_path}/pull-request-info" )
+		branch_name=$( jq -r '.feature_branch' "${project_path}/pull-request-info" )
 	else
 		pr_id=$(git config --get pullrequest.id)
 		branch_name=$(git config --get pullrequest.branch)


### PR DESCRIPTION
This adds bitbucket pr support for bitbucket resources that use the `pull-request-info` file.

This includes the following:
https://github.com/cathive/concourse-bitbucket-pullrequest-resource
https://github.com/philicious/concourse-git-bitbucket-pr-resource
https://github.com/zarplata/concourse-git-bitbucket-pr-resource