### PR TITLE
sonar.branch.name is incompatible with pull-request analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,13 @@ quality gate associated with a project are not met.
 * `branch_target_file`: File to be used to read the branch target.
   When this option has been specified, it has precedence over the `branch_target` parameter.
 
-* `decorate_pr`: If set to `true` it will try to fetch the pull request id and the head branch name from
-the pull request resource. It works for `telia-oss/github-pr-resource` and `jtarchie/github-pullrequest-resource`. It will enable `sonar.pullrequest.key` and `sonar.pullrequest.branch` flags when performing your analysis.
+* `decorate_pr`: If set to `true` it will try to fetch the pull request id, the head branch name and the base branch name from
+the pull request resource. It will enable `sonar.pullrequest.key`, `sonar.pullrequest.branch` and `sonar.pullrequest.base` flags when performing your analysis.
+
+  It works for:
+  * `telia-oss/github-pr-resource`
+  * `zarplata/concourse-git-bitbucket-pr-resource`
+  * `jtarchie/github-pullrequest-resource`
 
   >_In order to use this feature you must be using `SonarCloud` or `SonarQube Developer` edition._
 

--- a/assets/out
+++ b/assets/out
@@ -186,15 +186,18 @@ if [[ -n "${decorate_pr}" ]]; then
 	if [ -f "${project_path}/.git/resource/metadata.json" ]; then
 		pr_id=$( jq -r '.pr' "${project_path}/.git/resource/version.json" )
 		branch_name=$( jq -r '.[] | select (.name == "head_name") | .value' "${project_path}/.git/resource/metadata.json" )
+		base_branch_name=$( jq -r '.[] | select (.name == "base_name") | .value' "${project_path}/.git/resource/metadata.json" )
 	elif [ -f "${project_path}/pull-request-info" ]; then
 		pr_id=$( jq -r '.id' "${project_path}/pull-request-info" )
 		branch_name=$( jq -r '.feature_branch' "${project_path}/pull-request-info" )
+		base_branch_name=$( jq -r '.upstream_branch | ltrimstr("refs/heads/")' "${project_path}/pull-request-info" )
 	else
 		pr_id=$(git config --get pullrequest.id)
 		branch_name=$(git config --get pullrequest.branch)
+		base_branch_name=$(git config --get pullrequest.basebranch)
 	fi
 
-	scanner_opts+=" -Dsonar.pullrequest.key=${pr_id} -Dsonar.pullrequest.branch=${branch_name} -Dsonar.pullrequest.base=\"${sonar_branch_name}\""
+	scanner_opts+=" -Dsonar.pullrequest.key=${pr_id} -Dsonar.pullrequest.branch="${branch_name}" -Dsonar.pullrequest.base=\"${base_branch_name}\""
 	echo "Decorating PR: ${pr_id} for branch ${branch_name}"
 fi
 


### PR DESCRIPTION
This change enables correctly performing pull request analysis where the base branch is not the repository's default branch. `sonar.pullrequest.base` is configured based on pull request resource metadata instead of `sonar.branch.name`.

Previously, `sonar.branch.name` was used to set `sonar.pullrequest.base` and both parameters were passed to sonar-scanner. However, `sonar.branch.name` is incompatible with pull-request analysis resulting in scan failure. Not supplying `sonar.pullrequest.base` results in using the repository's default branch, which causes warnings and potentially incorrect diffs to be displayed in SonarQube when the base branch is not the repository's default branch.