### PR TITLE
Enable globstar.

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -212,7 +212,7 @@ function wildcard_convert {
     convert_res=""
     IFS=',';
     for wildcard in $wildcards; do
-        for w in ${project_path}/$wildcard; do
+        for w in $wildcard; do
             if [ "$( wildcard_exists "$w" )" -ne "0" ]; then
                 # Warning about path not exist, instead of fail/block the build.
                 echo "Warning: path [$w] does not exist under $(pwd)" >&2

--- a/assets/out
+++ b/assets/out
@@ -24,7 +24,7 @@ if [[ ! -d "${source}" ]]; then
 	exit 1
 fi
 
-cd "${source}/${project_path}"
+cd "${source}"
 
 payload=$(mktemp "${TMPDIR}/sonarqube-resource-out.XXXXXX")
 cat > "${payload}" <&0
@@ -45,6 +45,8 @@ if [[ ! -d "${project_path}" ]]; then
 	echo "error: Project path (${project_path}) not found or not a directory."
 	exit 1
 fi
+
+cd "${project_path}"
 
 sonar_host_url=$(jq -r '.source.host_url // ""' < "${payload}")
 if [[ -z "${sonar_host_url}" ]]; then

--- a/assets/out
+++ b/assets/out
@@ -5,6 +5,9 @@ set -e
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
+# enable globstar to support wildcard conversion
+shopt -s globstar
+
 root=$(dirname "${0}" | while read -r a; do cd "${a}" && pwd && break; done)
 export root
 # shellcheck source=./common.sh
@@ -21,7 +24,7 @@ if [[ ! -d "${source}" ]]; then
 	exit 1
 fi
 
-cd "${source}"
+cd "${source}/${project_path}"
 
 payload=$(mktemp "${TMPDIR}/sonarqube-resource-out.XXXXXX")
 cat > "${payload}" <&0
@@ -284,7 +287,6 @@ if [[ -n "${additional_properties_file}" ]]; then
 	done <<< "${props}"
 fi
 
-cd "${project_path}"
 echo "Starting sonar-scanner (type: ${scanner_type})..."
 eval "${scanner_bin} ${scanner_opts}"
 

--- a/assets/out
+++ b/assets/out
@@ -218,6 +218,7 @@ if [[ -n "${sonar_tests}" ]]; then
 	fi
 	scanner_opts+=" -Dsonar.tests=\"${sonar_tests}\""
 fi
+
 scanner_type=$(jq -r '.params.scanner_type // ""' < "${payload}")
 
 


### PR DESCRIPTION
What's the requirement? - https://github.com/cathive/concourse-sonarqube-resource/issues/60

changes:
assets/out -> enable globstar, change directory to {project_path} before wildcard_convert
assets/common.sh -> removed {project_path}

Above changes work for paths with globstar and no globstar; for example:
```
        sonar.exclusions: "functional-tests/**"
        sonar.java.binaries: "server/build/classes/java/main"
        sonar.java.test.binaries: "server/build/classes/java/test"
        sonar.java.libraries.reportPaths: "**/build/libs/**/*.jar"
        sonar.java.test.libraries.reportPaths: "**/build/libs/**/*.jar"
        sonar.jacoco.reportPaths: "**/build/jacoco/*.exec"
```