### PR TITLE
out: Fixing the error on CLI when maven settings file doesn't exist

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -36,7 +36,7 @@ echo "Preparing SonarQube scanner..."
 
 scanner_opts=""
 
-project_path=$(jq -r '.params.project_path // ""' < "${payload}")
+project_path=$source/$(jq -r '.params.project_path // ""' < "${payload}")
 if [[ -z "${project_path}" ]]; then
 	echo "error: params.project_path has not been specified."
 	exit 1
@@ -82,7 +82,9 @@ if [[ -n "${maven_settings}" ]]; then
 	unset maven_settings
 else
 	maven_settings_file=$(jq -r '.params.maven_settings_file // ""' < "${payload}")
-	maven_settings_file="$(realpath "${maven_settings_file}")"
+	if [[ -n "${maven_settings}" ]]; then
+		maven_settings_file="$(realpath "${maven_settings_file}")"
+	fi
 fi
 
 if [[ -n "${maven_settings_file}" ]]; then


### PR DESCRIPTION
Hello,

The current version was broken on CLI as the resource was looking for a maven settings file.
This commit is fixing it by adding an IF condition before trying to guess its path.

I also found a problem with PR identification in the decorate_pr attribute.
At the top of the resource, there is a `cd ${project_path}`
Then all conditions are checking for `${project_path}/.git`. The problem is that with the cd occurring above, it will never find this project path as we are already in.

There were three options:
1/ use the absolute path in the configuration of the resource
2/ remove the cd project_path at the top of the resource
3/ prefix the project path with the absolute path to make all conditions passing correctly

I went with the third option that was the less modifying/destroying the logic of the resource

If you want to give a try (testing that the fix for maven doesn't impact maven too), [here is my patched docker image](https://hub.docker.com/layers/cycloid/concourse-sonarqube-resource/latest/images/sha256-270ece22f4108f658b93ecd46658df3bdb0075663c0fd657d7271881ee5636b7?context=explore)

Closes #66 