### PR TITLE
Fix Maven Scan Types When Debug is Set to True

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -269,7 +269,7 @@ elif [[ "${scanner_type}" == "maven" ]]; then
 	fi
 
 	# shellcheck disable=SC2016
-	maven_project_build_directory=$(${mvn} -q -f "${project_path}/pom.xml" -Dexec.executable="echo" -Dexec.args='${project.build.directory}' --non-recursive exec:exec)
+	maven_project_build_directory=$(${mvn/-X} -q -f "${project_path}/pom.xml" -Dexec.executable="echo" -Dexec.args='${project.build.directory}' --non-recursive exec:exec)
 	scanner_report_file="${maven_project_build_directory}/sonar/report-task.txt"
 	unset maven_project_build_directory
 fi


### PR DESCRIPTION
When debug is set to `true`, the `-X` option is added to the `mvn`
command. However, the extra output from the command interferes with the
setting of the `maven_project_build_directory` variable.

A simple fix is to always remove the `-X` pattern from the `mvn`
command.