### PR TITLE
Bump Maven / Node / TypeScript versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # Global build arguments
 # ======================
 ARG RESOURCE_VERSION="0.14.1"
-ARG MAVEN_VERSION="3.8.6"
-ARG MAVEN_SHA512_CHECKSUM="f92dbd90060c5fd422349f844ea904a0918c9c9392f3277543ce2bfb0aab941950bb4174d9b6e2ea84cd48d2940111b83ffcc2e3acf5a5b2004277105fd22be9"
+ARG MAVEN_VERSION="3.8.7"
+ARG MAVEN_SHA512_CHECKSUM="c687fcdc3890bcf0f9f9dbc42ceded21dc80f0dcc5541c28912a99224694793f6e437998e46b5939bd314178865263c62a069c6c6f15d1d0541eea75748c46fd"
 ARG SONAR_SCANNER_CLI_VERSION="4.7.0.2747"
 ARG SONAR_SCANNER_CLI_SHA512_CHECKSUM="92475d0b32d15c3602657852e8670b862ba2d1a1ecafefbc40c2b176173375e21931ae94c5966f454d31e3dea7fb3033cec742498660cf0dc0ff9fa742a9fe4a"
 ARG SONAR_SCANNER_MAVEN_PLUGIN_VERSION="3.9.1.2184"
@@ -39,10 +39,10 @@ RUN apt-get -y update \
 && apt-get -y install bash curl gawk git jq shellcheck
 
 # Install nodejs 14
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt -y install nodejs
 
-ARG TYPESCRIPT_VERSION="3.9.7"
+ARG TYPESCRIPT_VERSION="4.9.4"
 RUN npm install -g typescript@${TYPESCRIPT_VERSION}
 
 RUN ln -sf "${JAVA_HOME}/bin/java" "/usr/local/bin/java" \
@@ -93,5 +93,3 @@ LABEL org.opencontainers.image.licenses="LicenseRef-apache-2.0"
 LABEL org.opencontainers.image.version="${RESOURCE_VERSION}"
 
 COPY ./assets/* /opt/resource/
-
-


### PR DESCRIPTION
- Maven 3.8.6 -> 3.8.7 (minor bump due to 3.8.6 missing from Apache CDN)
- NodeJS 14 -> 18 (bump to current recommended LTS build)
- TypeScript 3.9.7 -> 4.9.4 (3.9.7 is now nearly two years out of date)

Maven hash can be found https://downloads.apache.org/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.zip.sha512 to confirm value.